### PR TITLE
fix: only squeeze dimensions for integer indices

### DIFF
--- a/src/array_index.rs
+++ b/src/array_index.rs
@@ -65,7 +65,10 @@ impl<'py> FromPyObject<'_, 'py> for ArrayIndex {
 }
 
 impl ArrayIndex {
-    pub fn to_read_range(&self, shape: &Vec<u64>) -> PyResult<(Vec<Range<u64>>, Vec<usize>)> {
+    pub fn get_ranges_and_squeeze_dims(
+        &self,
+        shape: &Vec<u64>,
+    ) -> PyResult<(Vec<Range<u64>>, Vec<usize>)> {
         // Input validation
         if self.0.len() > shape.len() {
             return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
@@ -316,7 +319,7 @@ mod tests {
             let neg_tuple = pyo3::types::PyTuple::new(py, [&neg_idx]).unwrap();
             let index = ArrayIndex::extract(neg_tuple.as_any().as_borrowed()).unwrap();
             let ranges = index
-                .to_read_range(&shape)
+                .get_ranges_and_squeeze_dims(&shape)
                 .expect("Could not convert to read_range!")
                 .0;
             assert_eq!(ranges[0].start, 3); // -2 should map to index 3 in size 5
@@ -326,7 +329,7 @@ mod tests {
             let slice_tuple = pyo3::types::PyTuple::new(py, [&slice]).unwrap();
             let index = ArrayIndex::extract(slice_tuple.as_any().as_borrowed()).unwrap();
             let ranges = index
-                .to_read_range(&shape)
+                .get_ranges_and_squeeze_dims(&shape)
                 .expect("Could not convert to read_range!")
                 .0;
             assert_eq!(ranges[0].start, 2); // -3 should map to index 2
@@ -346,7 +349,7 @@ mod tests {
             // Test ..., 1
             let tuple = pyo3::types::PyTuple::new(py, [&ellipsis, &integer]).unwrap();
             let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let ranges = index.to_read_range(&shape).unwrap().0;
+            let ranges = index.get_ranges_and_squeeze_dims(&shape).unwrap().0;
             assert_eq!(ranges.len(), 4);
             assert_eq!(ranges[0], Range { start: 0, end: 2 });
             assert_eq!(ranges[1], Range { start: 0, end: 3 });
@@ -364,7 +367,7 @@ mod tests {
             )
             .unwrap();
             let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let ranges = index.to_read_range(&shape).unwrap().0;
+            let ranges = index.get_ranges_and_squeeze_dims(&shape).unwrap().0;
 
             assert_eq!(ranges.len(), 4);
             assert_eq!(ranges[0], Range { start: 1, end: 2 });
@@ -399,7 +402,7 @@ mod tests {
             let neg_idx = (-6i64).into_pyobject(py).unwrap();
             let neg_tuple = pyo3::types::PyTuple::new(py, [&neg_idx]).unwrap();
             let index = ArrayIndex::extract(neg_tuple.as_any().as_borrowed()).unwrap();
-            let _should_fail = index.to_read_range(&shape).unwrap();
+            let _should_fail = index.get_ranges_and_squeeze_dims(&shape).unwrap();
         });
     }
 
@@ -413,7 +416,7 @@ mod tests {
             let neg_idx = (-6i64).into_pyobject(py).unwrap();
             let neg_tuple = pyo3::types::PyTuple::new(py, [&neg_idx]).unwrap();
             let index = ArrayIndex::extract(neg_tuple.as_any().as_borrowed()).unwrap();
-            let _should_fail = index.to_read_range(&shape).unwrap();
+            let _should_fail = index.get_ranges_and_squeeze_dims(&shape).unwrap();
         });
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -472,7 +472,8 @@ impl OmFileReader {
                 let array_reader = reader
                     .expect_array_with_io_sizes(65536, 512)
                     .map_err(|_| Self::only_arrays_error())?;
-                let (read_ranges, squeeze_dims) = ranges.to_read_range(&self.shape)?;
+                let (read_ranges, squeeze_dims) =
+                    ranges.get_ranges_and_squeeze_dims(&self.shape)?;
                 let dtype = array_reader.data_type();
 
                 let untyped_py_array_or_error = match dtype {
@@ -638,7 +639,6 @@ fn read_and_process_array<T: Element + OmFileArrayDataType + Clone + Zero>(
         })
         .collect();
 
-    // Cheap O(1) reshape because data layout doesn't change
     Ok(array
         .into_shape_with_order(new_shape)
         .map_err(|e| PyValueError::new_err(e.to_string()))?)

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -431,7 +431,7 @@ impl OmFileReaderAsync {
     ///     TypeError: If the data type is not supported.
     async fn read_array<'py>(&self, ranges: ArrayIndex) -> PyResult<OmFileTypedArray> {
         // Convert the Python ranges to Rust ranges
-        let (read_ranges, squeeze_dims) = ranges.to_read_range(&self.shape)?;
+        let (read_ranges, squeeze_dims) = ranges.get_ranges_and_squeeze_dims(&self.shape)?;
 
         let guard = self.reader.try_read().unwrap();
 


### PR DESCRIPTION
Follow numpy indexing semantics:
- Integer indices remove that dimension
- Slice indices (even of length 1) preserve the dimension