### PR TITLE
fix: metadata traversal in legacy files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "omfiles"
 version = "0.1.0"
-source = "git+https://github.com/open-meteo/rust-omfiles?rev=2115e1bbab764c5628b4bad216864d3b2c062c5f#2115e1bbab764c5628b4bad216864d3b2c062c5f"
+source = "git+https://github.com/open-meteo/rust-omfiles?rev=a96adaf2c0808821452eaa5e54ea5032d5834184#a96adaf2c0808821452eaa5e54ea5032d5834184"
 dependencies = [
  "async-executor",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-lock = "3.4.2"
 numpy = "0.27"
 num-traits = "0.2"
 delegate = "0.13"
-omfiles-rs = { git = "https://github.com/open-meteo/rust-omfiles", rev = "2115e1bbab764c5628b4bad216864d3b2c062c5f", package = "omfiles", features = ["metadata-tree"] }
+omfiles-rs = { git = "https://github.com/open-meteo/rust-omfiles", rev = "a96adaf2c0808821452eaa5e54ea5032d5834184", package = "omfiles", features = ["metadata-tree"] }
 om-file-format-sys = { git = "https://github.com/open-meteo/om-file-format", rev = "9feec4b8f01fee2843ddb940ddc4dd92b2981437" }
 thiserror = "2.0.17"
 


### PR DESCRIPTION
Upstream fix for metadata traversal in legacy files: https://github.com/open-meteo/rust-omfiles/pull/42