### PR TITLE
fix: use scalar coordinates variable for array dimensions in xarray

### DIFF
--- a/examples/spatial_xarray.py
+++ b/examples/spatial_xarray.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "omfiles[fsspec,grids,xarray]>=1.1.2",  # x-release-please-version
+#     "omfiles[fsspec,grids,xarray] @ /home/fred/dev/terraputix/python-omfiles",  # x-release-please-version
 #     "matplotlib",
 #     "cartopy",
 # ]
@@ -20,16 +20,14 @@ import xarray as xr
 from omfiles.grids import OmGrid
 
 MODEL_DOMAIN = "dwd_icon"
-VARIABLE = "temperature_2m"
+VARIABLE = ""
 
 # Example: URI for a spatial data file in the `data_spatial` S3 bucket
 # See data organization details: https://github.com/open-meteo/open-data?tab=readme-ov-file#data-organization
 # Note: Spatial data is only retained for 7 days. The script uses one file within this period.
 date_time = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=2)
 S3_URI = (
-    f"s3://openmeteo/data_spatial/{MODEL_DOMAIN}/{date_time.year}/"
-    f"{date_time.month:02}/{date_time.day:02}/0000Z/"
-    f"{date_time.strftime('%Y-%m-%d')}T0000.om"
+    f"s3://openmeteo/data_run/{MODEL_DOMAIN}/{date_time.year}/{date_time.month:02}/{date_time.day:02}/0000Z/rain.om"
 )
 print(f"Using om file: {S3_URI}")
 
@@ -52,23 +50,23 @@ ax.add_feature(cfeature.BORDERS, linewidth=0.5)
 ax.add_feature(cfeature.OCEAN, alpha=0.3)
 ax.add_feature(cfeature.LAND, alpha=0.3)
 
-data = ds[VARIABLE]  # shape: (lat, lon)
+data = ds[VARIABLE][:, :, 2]  # shape: (lat, lon)
 # Use OmGrid with the crs_wkt attribute to get the lat/lon grid
-grid = OmGrid(ds.attrs["crs_wkt"], ds[VARIABLE].shape)
+grid = OmGrid(ds.attrs["crs_wkt"], data.shape)
 lon2d, lat2d = grid.get_meshgrid()
 
-min = int(data.min().values)
-max = int(data.max().values)
-stepsize = int((max - min) / 30)
+min_val = int(data.min().values)
+max_val = int(data.max().values)
+stepsize = int((max_val - min_val) / min(max_val - min_val, 30))
 
 im = ax.contourf(
     lon2d,
     lat2d,
     data,
-    levels=np.arange(min, max, stepsize),
+    levels=np.arange(min_val, max_val, stepsize),
     cmap="Spectral_r",
-    vmin=min,
-    vmax=max,
+    vmin=min_val,
+    vmax=max_val,
     extend="both",
 )
 ax.gridlines(draw_labels=True, alpha=0.3)

--- a/examples/spatial_xarray.py
+++ b/examples/spatial_xarray.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "omfiles[fsspec,grids,xarray] @ /home/fred/dev/terraputix/python-omfiles",  # x-release-please-version
+#     "omfiles[fsspec,grids,xarray]>=1.1.2",  # x-release-please-version
 #     "matplotlib",
 #     "cartopy",
 # ]
@@ -20,14 +20,16 @@ import xarray as xr
 from omfiles.grids import OmGrid
 
 MODEL_DOMAIN = "dwd_icon"
-VARIABLE = ""
+VARIABLE = "temperature_2m"
 
 # Example: URI for a spatial data file in the `data_spatial` S3 bucket
 # See data organization details: https://github.com/open-meteo/open-data?tab=readme-ov-file#data-organization
 # Note: Spatial data is only retained for 7 days. The script uses one file within this period.
 date_time = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=2)
 S3_URI = (
-    f"s3://openmeteo/data_run/{MODEL_DOMAIN}/{date_time.year}/{date_time.month:02}/{date_time.day:02}/0000Z/rain.om"
+    f"s3://openmeteo/data_spatial/{MODEL_DOMAIN}/{date_time.year}/"
+    f"{date_time.month:02}/{date_time.day:02}/0000Z/"
+    f"{date_time.strftime('%Y-%m-%d')}T0000.om"
 )
 print(f"Using om file: {S3_URI}")
 
@@ -50,9 +52,9 @@ ax.add_feature(cfeature.BORDERS, linewidth=0.5)
 ax.add_feature(cfeature.OCEAN, alpha=0.3)
 ax.add_feature(cfeature.LAND, alpha=0.3)
 
-data = ds[VARIABLE][:, :, 2]  # shape: (lat, lon)
+data = ds[VARIABLE]  # shape: (lat, lon)
 # Use OmGrid with the crs_wkt attribute to get the lat/lon grid
-grid = OmGrid(ds.attrs["crs_wkt"], data.shape)
+grid = OmGrid(ds.attrs["crs_wkt"], ds[VARIABLE].shape)
 lon2d, lat2d = grid.get_meshgrid()
 
 min_val = int(data.min().values)

--- a/python/omfiles/xarray.py
+++ b/python/omfiles/xarray.py
@@ -24,7 +24,7 @@ from xarray.core.variable import Variable
 from ._rust import OmFileReader, OmVariable
 
 # need some special secret attributes to tell us the dimensions
-DIMENSION_KEY = "_ARRAY_DIMENSIONS"
+DIMENSION_KEY = "coordinates"
 
 
 class OmXarrayEntrypoint(BackendEntrypoint):
@@ -118,7 +118,7 @@ class OmDataStore(AbstractDataStore):
             if DIMENSION_KEY in attrs:
                 dim_names = attrs[DIMENSION_KEY]
                 if isinstance(dim_names, str):
-                    dimensions.update(dim_names.split(","))
+                    dimensions.update(dim_names.split(" "))
                 elif isinstance(dim_names, list):
                     dimensions.update(dim_names)
 
@@ -141,7 +141,7 @@ class OmDataStore(AbstractDataStore):
                 dim_names = attrs[DIMENSION_KEY]
                 if isinstance(dim_names, str):
                     # Dimensions are stored as a comma-separated string, split them
-                    dim_names = dim_names.split(",")
+                    dim_names = dim_names.split(" ")
             else:
                 # Default to generic dimension names if not specified
                 dim_names = [f"dim{i}" for i in range(len(shape))]

--- a/python/omfiles/xarray.py
+++ b/python/omfiles/xarray.py
@@ -118,7 +118,7 @@ class OmDataStore(AbstractDataStore):
             if DIMENSION_KEY in attrs:
                 dim_names = attrs[DIMENSION_KEY]
                 if isinstance(dim_names, str):
-                    dimensions.update(dim_names.split(" "))
+                    dimensions.update(dim_names.split())
                 elif isinstance(dim_names, list):
                     dimensions.update(dim_names)
 
@@ -140,8 +140,14 @@ class OmDataStore(AbstractDataStore):
             if DIMENSION_KEY in attrs:
                 dim_names = attrs[DIMENSION_KEY]
                 if isinstance(dim_names, str):
-                    # Dimensions are stored as a comma-separated string, split them
-                    dim_names = dim_names.split(" ")
+                    # Dimensions are stored as white space separated string, split them
+                    #
+                    # If sep is not specified or is None, a different splitting algorithm is applied:
+                    # runs of consecutive whitespace are regarded as a single separator, and the result will
+                    # contain no empty strings at the start or end if the string has leading or trailing
+                    # whitespace. Consequently, splitting an empty string or a string consisting of just
+                    # whitespace with a None separator returns [].
+                    dim_names = dim_names.split()
             else:
                 # Default to generic dimension names if not specified
                 dim_names = [f"dim{i}" for i in range(len(shape))]

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -60,7 +60,7 @@ def test_xarray_hierarchical_file(empty_temp_om_file):
     writer = OmFileWriter(empty_temp_om_file)
 
     # dimensionality metadata
-    temperature_dimension_var = writer.write_scalar("LATITUDE,LONGITUDE,ALTITUDE,TIME", name="_ARRAY_DIMENSIONS")
+    temperature_dimension_var = writer.write_scalar("LATITUDE LONGITUDE ALTITUDE TIME", name="coordinates")
     temp_units = writer.write_scalar("celsius", name="units")
     temp_metadata = writer.write_scalar("Surface temperature", name="description")
 
@@ -74,7 +74,7 @@ def test_xarray_hierarchical_file(empty_temp_om_file):
     )
 
     # dimensionality metadata
-    precipitation_dimension_var = writer.write_scalar("LATITUDE,LONGITUDE,TIME", name="_ARRAY_DIMENSIONS")
+    precipitation_dimension_var = writer.write_scalar("LATITUDE LONGITUDE TIME", name="coordinates")
     precip_units = writer.write_scalar("mm", name="units")
     precip_metadata = writer.write_scalar("Precipitation", name="description")
 


### PR DESCRIPTION
### Summary 

- Switched the xarray backend’s dimension metadata key from `_ARRAY_DIMENSIONS` to `coordinates`.
- Updated dimension-name parsing from comma-separated to space-separated strings.
- Adjusted the hierarchical xarray test to write `coordinates` metadata in the new format.

This is how the open-meteo project currently stores dimensions/coordinates.
