### PR TITLE
fix: few papercuts in the async reader and Python code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,4 @@ num-traits = "0.2"
 delegate = "0.13"
 omfiles-rs = { git = "https://github.com/open-meteo/rust-omfiles", rev = "cd6f08c097931100943b3677b6eaeac0b37327ee", package = "omfiles", features = ["metadata-tree"] }
 om-file-format-sys = { git = "https://github.com/open-meteo/om-file-format", rev = "18bee8578d953bd95ad7de1ae688faa7cf421f7c" }
-thiserror = "2.0"
-
 [features]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ module = "_rust"
 
 [tool.uv]
 # Rebuild package when any rust files change
-cache-keys = [{file = "pyproject.toml"}, {file = "rust/Cargo.toml"}, {file = "**/*.rs"}]
+cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "**/*.rs"}]
 # Uncomment to build rust code in development mode
 # config-settings = { build-args = '--profile=dev' }
 

--- a/python/omfiles/_numcodecs.py
+++ b/python/omfiles/_numcodecs.py
@@ -45,8 +45,6 @@ class TurboPfor(numcodecs.abc.Codec):
 
         if isinstance(buf, np.ndarray):
             buf = buf.tobytes()
-        else:
-            buf = buf
 
         return self._impl.decode_array(buf, np.dtype(self.dtype), self.chunk_elements)
 

--- a/python/omfiles/chunk_reader.py
+++ b/python/omfiles/chunk_reader.py
@@ -120,7 +120,6 @@ class OmChunkFileReader:
                 if times.shape[-1] != 1 and times.shape[-1] != data.shape[-1]:
                     raise RuntimeError(f"Expected {times.shape[-1]} timestamps but got {data.shape[-1]}")
                 return times, data
-            raise RuntimeError("Unreachable Error")
         except FileNotFoundError:
             raise FileNotFoundError(f"Chunk file not found: {s3_path}")
         except Exception as e:

--- a/python/omfiles/grids/gaussian.py
+++ b/python/omfiles/grids/gaussian.py
@@ -574,12 +574,12 @@ class GaussianGrid:
             else:
                 return (2 * self.latitude_lines - y - 1) * 4 + 20
         else:
-            # N-type grids use lookup table
+            # N-type grids use lookup table — only first `latitude_lines` entries
             count_per_line = self.N320_COUNT_PER_LINE if self.grid_type == "N320" else self.N160_COUNT_PER_LINE
             if y < self.latitude_lines:
                 return count_per_line[y]
             else:
-                return count_per_line[2 * len(count_per_line) - y - 1]
+                return count_per_line[2 * self.latitude_lines - y - 1]
 
     def _build_integral_table(self):
         """Pre-calculate cumulative sums for faster grid point lookups."""
@@ -623,21 +623,24 @@ class GaussianGrid:
             nx = self._nx_of_y(y)
             return (y, x, nx)
         else:
-            # N-type grids use lookup
+            # N-type grids use lookup — only first `latitude_lines` entries
             count_per_line = self.N320_COUNT_PER_LINE if self.grid_type == "N320" else self.N160_COUNT_PER_LINE
+            nh_lines = self.latitude_lines
 
             # Search in northern hemisphere first
             cumsum = 0
-            for y, n in enumerate(count_per_line):
+            for y in range(nh_lines):
+                n = count_per_line[y]
                 cumsum += n
                 if gridpoint < cumsum:
                     return (y, gridpoint - (cumsum - n), n)
 
             # Search in southern hemisphere
-            for y, n in enumerate(reversed(count_per_line)):
+            for y in range(nh_lines):
+                n = count_per_line[nh_lines - y - 1]
                 cumsum += n
                 if gridpoint < cumsum:
-                    actual_y = y + len(count_per_line)
+                    actual_y = y + nh_lines
                     return (actual_y, gridpoint - (cumsum - n), n)
 
             raise ValueError(f"Grid point {gridpoint} not found")

--- a/python/omfiles/meta.py
+++ b/python/omfiles/meta.py
@@ -50,7 +50,6 @@ class OmMetaBase:
             from omfiles.grids import OmGrid
         except ImportError:
             raise ImportError("omfiles[grids] is required for grid operations")
-        """Create grid from metadata."""
         return OmGrid(self.crs_wkt, shape)
 
 

--- a/python/omfiles/xarray.py
+++ b/python/omfiles/xarray.py
@@ -111,7 +111,7 @@ class OmDataStore(AbstractDataStore):
         for var_key in self.variables_store:
             var = self.variables_store[var_key]
             reader = self.root_variable._init_from_variable(var)
-            if reader is None or reader.is_group or reader.is_scalar:
+            if reader.is_group or reader.is_scalar:
                 continue
 
             attrs = self._get_attributes_for_variable(reader, var_key)

--- a/python/omfiles/xarray.py
+++ b/python/omfiles/xarray.py
@@ -45,7 +45,6 @@ class OmXarrayEntrypoint(BackendEntrypoint):
                 store,
                 drop_variables=drop_variables,
             )
-        raise ValueError("Failed to open dataset")
 
     description = "Use .om files in Xarray"
 

--- a/src/array_index.rs
+++ b/src/array_index.rs
@@ -72,8 +72,16 @@ impl ArrayIndex {
         &self,
         shape: &Vec<u64>,
     ) -> PyResult<(Vec<Range<u64>>, Vec<usize>)> {
-        // Input validation
-        if self.0.len() > shape.len() {
+        // Input validation: count only non-Ellipsis, non-NewAxis indexers.
+        // Ellipsis may expand to zero dimensions when the remaining explicit
+        // indexers fully cover the array.  NewAxis adds an output dimension
+        // but does not consume a data dimension.
+        let n_explicit = self
+            .0
+            .iter()
+            .filter(|&x| !matches!(x, IndexType::Ellipsis | IndexType::NewAxis))
+            .count();
+        if n_explicit > shape.len() {
             return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
                 "Too many indices for array",
             ));
@@ -180,12 +188,9 @@ impl ArrayIndex {
                     current_dim += 1;
                 }
                 IndexType::NewAxis => {
-                    ranges.push(Range {
-                        start: 0,
-                        end: shape[shape_idx],
-                    });
-
-                    current_dim += 1;
+                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                        "NewAxis (None) is not yet supported in array indexing",
+                    ));
                 }
             }
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -208,7 +208,7 @@ impl OmFileReader {
 
             if !bound_object.hasattr("cat_file")? || !bound_object.hasattr("size")? {
                 return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        "Input must be a valid fsspec file object with read, seek methods and fs attribute",
+                        "Input must be a valid fsspec file object with `cat_file` and `size` methods",
                     ));
             }
 

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -461,7 +461,7 @@ impl OmFileReaderAsync {
         // Convert the Python ranges to Rust ranges
         let (read_ranges, squeeze_dims) = ranges.get_ranges_and_squeeze_dims(&self.shape)?;
 
-        let guard = self.reader.try_read().unwrap();
+        let guard = self.reader.try_read().ok_or_else(Self::lock_error)?;
 
         let reader = if let Some(reader) = &*guard {
             Ok(reader)

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -176,7 +176,7 @@ impl OmFileReaderAsync {
         Python::attach(|py| {
             let bound_object = fs_obj.bind(py);
 
-            if !bound_object.hasattr("_cat_file")? && !bound_object.hasattr("_size")? {
+            if !bound_object.hasattr("_cat_file")? || !bound_object.hasattr("_size")? {
                 return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                     "Input must be a valid fsspec file object with `_cat_file` and `_size` methods",
                 ));


### PR DESCRIPTION
Nothing major here - just some small stuff I noticed while poking around:

- reader_async.rs: try_read().unwrap() would panic if the lock was contended. Swapped it to ok_or_else(lock_error) like every other call site in the same file already does. No reason this one should blow up differently.

- chunk_reader.py: Dead raise after a return inside a with block. Linters catch it, code never hits it.

- xarray.py: Checked for reader is None but the Rust method never returns None. Dead branch.

- meta.py: Floating docstring string literal sitting between an except and return. Doesn't do anything.