### PR TITLE
fix: align indexing with other file backed ndarray implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ with OmFileReader(backend) as root:
     print(temperature_data_subset1)
     print(f"temperature_data_subset1.shape: {temperature_data_subset1.shape}")  # (10, 10)
 
-    # Numpy basic indexing is supported for direct access if the reader is an array.
+    # Integer, slice, and ellipsis indexing is supported for direct access if the reader is an array.
     temperature_data_subset2 = temperature_reader[0:10, 0:10]
     print(temperature_data_subset2)
     print(f"temperature_data_subset2.shape: {temperature_data_subset2.shape}")  # (10, 10)

--- a/python/omfiles/_rust/__init__.pyi
+++ b/python/omfiles/_rust/__init__.pyi
@@ -243,6 +243,7 @@ class OmFileReader:
         r"""
         Read data from the open variable.om file using basic file-backed array indexing.
 
+        Slice bounds are clipped to the array dimensions and empty selections return empty arrays.
         Currently only slices with step 1 are supported.
 
         Supports integer, slice, and ellipsis selectors:
@@ -495,6 +496,9 @@ class OmFileReaderAsync:
     ]:
         r"""
         Read data from the array concurrently based on specified ranges.
+
+        Slice bounds are clipped to the array dimensions and empty selections return empty arrays.
+        Currently only slices with step 1 are supported.
 
         Args:
             ranges (:py:data:`omfiles.types.BasicSelection`): Integer, slice, or ellipsis expression specifying the

--- a/python/omfiles/_rust/__init__.pyi
+++ b/python/omfiles/_rust/__init__.pyi
@@ -241,22 +241,24 @@ class OmFileReader:
         ]
     ]:
         r"""
-        Read data from the open variable.om file using numpy-style indexing.
+        Read data from the open variable.om file using basic file-backed array indexing.
 
         Currently only slices with step 1 are supported.
 
-        Follows NumPy indexing semantics:
+        Supports integer, slice, and ellipsis selectors:
         - Integer indices remove that dimension
         - Slice indices (even of length 1) preserve the dimension
+        - Ellipsis expands to the remaining dimensions
 
         Args:
             ranges (:py:data:`omfiles.types.BasicSelection`): Index expression to select data from the array.
-                Supports basic numpy indexing.
+                Supports integers, slices, and ellipsis. ``None``/``numpy.newaxis`` is not supported.
 
         Returns:
             numpy.typing.NDArray[numpy.int8 | numpy.int16 | numpy.int32 | numpy.int64 | numpy.uint8 | numpy.uint16 | numpy.uint32 | numpy.uint64 | numpy.float32 | numpy.float64]: NDArray containing the requested data with squeezed singleton dimensions.
 
         Raises:
+            IndexError: If a selector is unsupported or there are too many indices.
             ValueError: If the requested ranges are invalid or if there's an error reading the data.
         """
     def __getitem__(
@@ -495,12 +497,14 @@ class OmFileReaderAsync:
         Read data from the array concurrently based on specified ranges.
 
         Args:
-            ranges (:py:data:`omfiles.types.BasicSelection`): Index or slice object specifying the ranges to read.
+            ranges (:py:data:`omfiles.types.BasicSelection`): Integer, slice, or ellipsis expression specifying the
+                ranges to read. ``None``/``numpy.newaxis`` is not supported.
 
         Returns:
             OmFileTypedArray: Array data of the appropriate numpy type.
 
         Raises:
+            IndexError: If a selector is unsupported or there are too many indices.
             ValueError: If the reader is closed.
             TypeError: If the data type is not supported.
         """

--- a/src/array_index.rs
+++ b/src/array_index.rs
@@ -73,9 +73,9 @@ impl<'py> FromPyObject<'_, 'py> for ArrayIndex {
 }
 
 impl ArrayIndex {
-    pub fn get_ranges_and_squeeze_dims(
+    pub fn get_ranges_and_output_shape(
         &self,
-        shape: &Vec<u64>,
+        shape: &[u64],
     ) -> PyResult<(Vec<Range<u64>>, Vec<usize>)> {
         // Count how many actual dimensions are consumed by non-ellipsis indices.
         let consumed_dims: usize = self
@@ -90,8 +90,7 @@ impl ArrayIndex {
         }
 
         let mut ranges = Vec::new();
-        let mut squeeze_dims = Vec::new();
-        let mut current_dim = 0;
+        let mut output_shape = Vec::new();
 
         let mut shape_idx = 0;
         let mut ellipsis_seen = false;
@@ -115,8 +114,8 @@ impl ArrayIndex {
                             start: 0,
                             end: shape[shape_idx],
                         });
+                        output_shape.push(shape[shape_idx] as usize);
                         shape_idx += 1;
-                        current_dim += 1;
                     }
                     ellipsis_seen = true;
                 }
@@ -126,10 +125,8 @@ impl ArrayIndex {
                         start: normalized_idx,
                         end: normalized_idx + 1,
                     });
-                    squeeze_dims.push(current_dim);
 
                     shape_idx += 1;
-                    current_dim += 1;
                 }
                 IndexType::Slice { start, stop, step } => {
                     if let Some(step) = step {
@@ -141,51 +138,21 @@ impl ArrayIndex {
                     }
                     let dim_size = shape[shape_idx];
 
-                    let start_idx = match start {
-                        Some(s) => {
-                            let normalized = Self::normalize_index(*s, dim_size)?;
-                            if normalized > dim_size {
-                                return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                                    format!(
-                                        "Index {} is out of bounds for axis with size {}",
-                                        s, dim_size
-                                    ),
-                                ));
-                            }
-                            normalized
-                        }
-                        None => 0,
-                    };
-
-                    let stop_idx = match stop {
-                        Some(s) => {
-                            let normalized = Self::normalize_index(*s, dim_size)?;
-                            if normalized > dim_size {
-                                return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                                    format!(
-                                        "Index {} is out of bounds for axis with size {}",
-                                        s, dim_size
-                                    ),
-                                ));
-                            }
-                            normalized
-                        }
-                        None => dim_size,
-                    };
-
-                    if stop_idx <= start_idx {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "omfiles currently do not support reversed ranges.",
-                        ));
-                    }
+                    let start_idx = start
+                        .map(|index| Self::normalize_slice_bound(index, dim_size))
+                        .unwrap_or(0);
+                    let stop_idx = stop
+                        .map(|index| Self::normalize_slice_bound(index, dim_size))
+                        .unwrap_or(dim_size)
+                        .max(start_idx);
 
                     ranges.push(Range {
                         start: start_idx,
                         end: stop_idx,
                     });
+                    output_shape.push((stop_idx - start_idx) as usize);
 
                     shape_idx += 1;
-                    current_dim += 1;
                 }
             }
         }
@@ -196,25 +163,35 @@ impl ArrayIndex {
                 start: 0,
                 end: shape[shape_idx],
             });
+            output_shape.push(shape[shape_idx] as usize);
             shape_idx += 1;
         }
-        squeeze_dims.sort_by(|a, b| b.cmp(a));
 
-        Ok((ranges, squeeze_dims))
+        Ok((ranges, output_shape))
     }
 
     fn normalize_index(idx: i64, dim_size: u64) -> PyResult<u64> {
-        let dim_size_i64 = dim_size as i64;
-        let normalized = if idx < 0 { idx + dim_size_i64 } else { idx };
+        let normalized = if idx < 0 {
+            dim_size.checked_sub(idx.unsigned_abs())
+        } else {
+            let idx = idx as u64;
+            (idx < dim_size).then_some(idx)
+        };
 
-        if normalized < 0 || normalized > dim_size_i64 {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+        normalized.ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
                 "Index {} is out of bounds for axis with size {}",
                 idx, dim_size
-            )));
-        }
+            ))
+        })
+    }
 
-        Ok(normalized as u64)
+    fn normalize_slice_bound(idx: i64, dim_size: u64) -> u64 {
+        if idx < 0 {
+            dim_size.saturating_sub(idx.unsigned_abs())
+        } else {
+            (idx as u64).min(dim_size)
+        }
     }
 }
 
@@ -305,7 +282,7 @@ mod tests {
             let neg_tuple = pyo3::types::PyTuple::new(py, [&neg_idx]).unwrap();
             let index = ArrayIndex::extract(neg_tuple.as_any().as_borrowed()).unwrap();
             let ranges = index
-                .get_ranges_and_squeeze_dims(&shape)
+                .get_ranges_and_output_shape(&shape)
                 .expect("Could not convert to read_range!")
                 .0;
             assert_eq!(ranges[0].start, 3); // -2 should map to index 3 in size 5
@@ -315,7 +292,7 @@ mod tests {
             let slice_tuple = pyo3::types::PyTuple::new(py, [&slice]).unwrap();
             let index = ArrayIndex::extract(slice_tuple.as_any().as_borrowed()).unwrap();
             let ranges = index
-                .get_ranges_and_squeeze_dims(&shape)
+                .get_ranges_and_output_shape(&shape)
                 .expect("Could not convert to read_range!")
                 .0;
             assert_eq!(ranges[0].start, 2); // -3 should map to index 2
@@ -335,12 +312,13 @@ mod tests {
             // Test ..., 1
             let tuple = pyo3::types::PyTuple::new(py, [&ellipsis, &integer]).unwrap();
             let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let ranges = index.get_ranges_and_squeeze_dims(&shape).unwrap().0;
+            let (ranges, output_shape) = index.get_ranges_and_output_shape(&shape).unwrap();
             assert_eq!(ranges.len(), 4);
             assert_eq!(ranges[0], Range { start: 0, end: 2 });
             assert_eq!(ranges[1], Range { start: 0, end: 3 });
             assert_eq!(ranges[2], Range { start: 0, end: 4 });
             assert_eq!(ranges[3], Range { start: 1, end: 2 });
+            assert_eq!(output_shape, vec![2, 3, 4]);
 
             // Test 1, ..., 2
             let tuple = pyo3::types::PyTuple::new(
@@ -353,13 +331,14 @@ mod tests {
             )
             .unwrap();
             let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let ranges = index.get_ranges_and_squeeze_dims(&shape).unwrap().0;
+            let (ranges, output_shape) = index.get_ranges_and_output_shape(&shape).unwrap();
 
             assert_eq!(ranges.len(), 4);
             assert_eq!(ranges[0], Range { start: 1, end: 2 });
             assert_eq!(ranges[1], Range { start: 0, end: 3 });
             assert_eq!(ranges[2], Range { start: 0, end: 4 });
             assert_eq!(ranges[3], Range { start: 2, end: 3 });
+            assert_eq!(output_shape, vec![3, 4]);
         });
     }
 
@@ -381,30 +360,50 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_invalid_negative_index() {
-        Python::initialize();
+    fn test_integer_bounds() {
+        let shape = vec![5];
 
-        Python::attach(|py| {
-            let shape = vec![5];
-            let neg_idx = (-6i64).into_pyobject(py).unwrap();
-            let neg_tuple = pyo3::types::PyTuple::new(py, [&neg_idx]).unwrap();
-            let index = ArrayIndex::extract(neg_tuple.as_any().as_borrowed()).unwrap();
-            let _should_fail = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-        });
+        let first = ArrayIndex(vec![IndexType::Int(-5)])
+            .get_ranges_and_output_shape(&shape)
+            .unwrap();
+        assert_eq!(first.0, vec![Range { start: 0, end: 1 }]);
+
+        assert!(ArrayIndex(vec![IndexType::Int(5)])
+            .get_ranges_and_output_shape(&shape)
+            .is_err());
+        assert!(ArrayIndex(vec![IndexType::Int(-6)])
+            .get_ranges_and_output_shape(&shape)
+            .is_err());
     }
 
     #[test]
-    #[should_panic]
-    fn test_invalid_slice() {
-        Python::initialize();
+    fn test_slice_clipping_and_empty_ranges() {
+        let shape = vec![5];
+        let cases = [
+            ((Some(-99), None), Range { start: 0, end: 5 }),
+            ((None, Some(99)), Range { start: 0, end: 5 }),
+            ((Some(99), None), Range { start: 5, end: 5 }),
+            ((None, Some(-99)), Range { start: 0, end: 0 }),
+            ((Some(3), Some(1)), Range { start: 3, end: 3 }),
+        ];
 
-        Python::attach(|py| {
-            let shape = vec![5];
-            let neg_idx = (-6i64).into_pyobject(py).unwrap();
-            let neg_tuple = pyo3::types::PyTuple::new(py, [&neg_idx]).unwrap();
-            let index = ArrayIndex::extract(neg_tuple.as_any().as_borrowed()).unwrap();
-            let _should_fail = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-        });
+        for ((start, stop), expected) in cases {
+            let resolved = ArrayIndex(vec![IndexType::Slice {
+                start,
+                stop,
+                step: None,
+            }])
+            .get_ranges_and_output_shape(&shape)
+            .unwrap();
+            assert_eq!(resolved.0, vec![expected]);
+        }
+
+        assert!(ArrayIndex(vec![IndexType::Slice {
+            start: None,
+            stop: None,
+            step: Some(2),
+        }])
+        .get_ranges_and_output_shape(&shape)
+        .is_err());
     }
 }

--- a/src/array_index.rs
+++ b/src/array_index.rs
@@ -71,9 +71,14 @@ impl ArrayIndex {
     pub fn get_ranges_and_squeeze_dims(
         &self,
         shape: &Vec<u64>,
-    ) -> PyResult<(Vec<Range<u64>>, Vec<usize>)> {
-        // Input validation
-        if self.0.len() > shape.len() {
+    ) -> PyResult<(Vec<Range<u64>>, Vec<usize>, Vec<usize>)> {
+        // Count how many actual dimensions are consumed by non-NewAxis indices
+        let consumed_dims: usize = self
+            .0
+            .iter()
+            .filter(|&x| !matches!(x, IndexType::NewAxis | IndexType::Ellipsis))
+            .count();
+        if consumed_dims > shape.len() {
             return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
                 "Too many indices for array",
             ));
@@ -81,6 +86,7 @@ impl ArrayIndex {
 
         let mut ranges = Vec::new();
         let mut squeeze_dims = Vec::new();
+        let mut newaxis_dims = Vec::new();
         let mut current_dim = 0;
 
         let mut shape_idx = 0;
@@ -88,7 +94,7 @@ impl ArrayIndex {
         let explicit_dims: usize = self
             .0
             .iter()
-            .filter(|&x| !matches!(x, IndexType::Ellipsis))
+            .filter(|&x| !matches!(x, IndexType::Ellipsis | IndexType::NewAxis))
             .count();
         let ellipsis_dims = shape.len().saturating_sub(explicit_dims);
 
@@ -100,7 +106,6 @@ impl ArrayIndex {
                             "Only one ellipsis allowed in index",
                         ));
                     }
-                    // Add full ranges for all dimensions represented by the ellipsis
                     for _ in 0..ellipsis_dims {
                         ranges.push(Range {
                             start: 0,
@@ -117,7 +122,6 @@ impl ArrayIndex {
                         start: normalized_idx,
                         end: normalized_idx + 1,
                     });
-                    // Mark this dimension for squeezing
                     squeeze_dims.push(current_dim);
 
                     shape_idx += 1;
@@ -180,11 +184,7 @@ impl ArrayIndex {
                     current_dim += 1;
                 }
                 IndexType::NewAxis => {
-                    ranges.push(Range {
-                        start: 0,
-                        end: shape[shape_idx],
-                    });
-
+                    newaxis_dims.push(current_dim);
                     current_dim += 1;
                 }
             }
@@ -198,11 +198,23 @@ impl ArrayIndex {
             });
             shape_idx += 1;
         }
-        // We must sort squeeze_dims in descending order so removing one doesn't shift
-        // the indices of subsequent ones we want to remove.
         squeeze_dims.sort_by(|a, b| b.cmp(a));
 
-        Ok((ranges, squeeze_dims))
+        // Adjust squeeze_dims from output space to read-array space:
+        // each NewAxis before a squeeze dim shifts it left by 1.
+        for pos in squeeze_dims.iter_mut() {
+            let shift = newaxis_dims.iter().filter(|&&n| n < *pos).count();
+            *pos -= shift;
+        }
+
+        // Adjust newaxis_dims from output space to post-squeeze space:
+        // each squeezed dim before a NewAxis shifts it left by 1.
+        for pos in newaxis_dims.iter_mut() {
+            let shift = squeeze_dims.iter().filter(|&&s| s < *pos).count();
+            *pos -= shift;
+        }
+
+        Ok((ranges, squeeze_dims, newaxis_dims))
     }
 
     fn normalize_index(idx: i64, dim_size: u64) -> PyResult<u64> {
@@ -377,6 +389,123 @@ mod tests {
             assert_eq!(ranges[1], Range { start: 0, end: 3 });
             assert_eq!(ranges[2], Range { start: 0, end: 4 });
             assert_eq!(ranges[3], Range { start: 2, end: 3 });
+        });
+    }
+
+    #[test]
+    fn test_newaxis() {
+        Python::initialize();
+
+        Python::attach(|py| {
+            // arr[np.newaxis] on shape (5,)
+            let shape = vec![5];
+            let none = py.None();
+            let none_value = none.bind(py);
+            let tuple = pyo3::types::PyTuple::new(py, [none_value]).unwrap();
+            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
+            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
+            assert_eq!(ranges.len(), 1);
+            assert_eq!(ranges[0], Range { start: 0, end: 5 });
+            assert!(squeeze.is_empty());
+            assert_eq!(newaxis, vec![0]);
+
+            // arr[np.newaxis, :3] on shape (5,)
+            let slice = PySlice::new(py, 0, 3, 1);
+            let tuple = pyo3::types::PyTuple::new(
+                py,
+                [none_value, &slice.into_any()],
+            )
+            .unwrap();
+            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
+            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
+            assert_eq!(ranges.len(), 1);
+            assert_eq!(ranges[0], Range { start: 0, end: 3 });
+            assert!(squeeze.is_empty());
+            assert_eq!(newaxis, vec![0]);
+
+            // arr[1, np.newaxis] on shape (5,)
+            let int_value = 1i64.into_pyobject(py).unwrap();
+            let tuple = pyo3::types::PyTuple::new(
+                py,
+                [&int_value.clone().into_any(), none_value],
+            )
+            .unwrap();
+            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
+            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
+            assert_eq!(ranges.len(), 1);
+            assert_eq!(ranges[0], Range { start: 1, end: 2 });
+            assert_eq!(squeeze, vec![0]);
+            assert_eq!(newaxis, vec![0]);
+
+            // arr[np.newaxis, 1] on shape (5,) — newaxis then int
+            let tuple = pyo3::types::PyTuple::new(
+                py,
+                [none_value, &int_value.into_any()],
+            )
+            .unwrap();
+            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
+            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
+            assert_eq!(ranges.len(), 1);
+            assert_eq!(ranges[0], Range { start: 1, end: 2 });
+            assert_eq!(squeeze, vec![0]);
+            assert_eq!(newaxis, vec![0]);
+
+            // arr[np.newaxis, np.newaxis] on shape (5,) — two newaxis
+            let tuple = pyo3::types::PyTuple::new(
+                py,
+                [none_value, none_value],
+            )
+            .unwrap();
+            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
+            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
+            assert_eq!(ranges.len(), 1);
+            assert_eq!(ranges[0], Range { start: 0, end: 5 });
+            assert!(squeeze.is_empty());
+            assert_eq!(newaxis, vec![0, 1]);
+        });
+    }
+
+    #[test]
+    fn test_ellipsis_with_newaxis() {
+        Python::initialize();
+
+        Python::attach(|py| {
+            let shape = vec![2, 3, 4, 5];
+            let ellipsis = pyo3::types::PyEllipsis::get(py).into_any();
+            let none = py.None();
+            let none_value = none.bind(py);
+
+            // arr[..., np.newaxis] on shape (2,3,4,5)
+            let tuple = pyo3::types::PyTuple::new(
+                py,
+                [&ellipsis, none_value],
+            )
+            .unwrap();
+            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
+            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
+            assert_eq!(ranges.len(), 4);
+            assert_eq!(ranges[0], Range { start: 0, end: 2 });
+            assert_eq!(ranges[1], Range { start: 0, end: 3 });
+            assert_eq!(ranges[2], Range { start: 0, end: 4 });
+            assert_eq!(ranges[3], Range { start: 0, end: 5 });
+            assert!(squeeze.is_empty());
+            assert_eq!(newaxis, vec![4]);
+
+            // arr[np.newaxis, ...] on shape (2,3,4,5)
+            let tuple = pyo3::types::PyTuple::new(
+                py,
+                [none_value, &ellipsis],
+            )
+            .unwrap();
+            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
+            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
+            assert_eq!(ranges.len(), 4);
+            assert_eq!(ranges[0], Range { start: 0, end: 2 });
+            assert_eq!(ranges[1], Range { start: 0, end: 3 });
+            assert_eq!(ranges[2], Range { start: 0, end: 4 });
+            assert_eq!(ranges[3], Range { start: 0, end: 5 });
+            assert!(squeeze.is_empty());
+            assert_eq!(newaxis, vec![0]);
         });
     }
 

--- a/src/array_index.rs
+++ b/src/array_index.rs
@@ -18,7 +18,7 @@ impl pyo3_stub_gen::PyStubType for ArrayIndex {
 
 /// A simplified numpy-like array basic indexing implementation.
 /// Compare https://numpy.org/doc/stable/user/basics.indexing.html.
-/// Supports integer, slice, newaxis and ellipsis indexing.
+/// Supports integer, slice and ellipsis indexing.
 /// Slice indexing is also currently limited to step size 1!
 #[derive(Debug)]
 pub enum IndexType {
@@ -28,7 +28,6 @@ pub enum IndexType {
         stop: Option<i64>,
         step: Option<i64>,
     },
-    NewAxis,
     Ellipsis,
 }
 
@@ -48,10 +47,16 @@ impl<'py> FromPyObject<'_, 'py> for ArrayIndex {
                 Ok(IndexType::Slice { start, stop, step })
             } else if item.is_instance_of::<pyo3::types::PyEllipsis>() {
                 Ok(IndexType::Ellipsis)
-            } else if item.is_none() {
-                Ok(IndexType::NewAxis)
             } else {
-                Ok(IndexType::Int(item.extract()?))
+                match item.extract() {
+                    Ok(index) => Ok(IndexType::Int(index)),
+                    Err(_) => {
+                        let item_type = item.get_type().repr()?.extract::<String>()?;
+                        Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                            "unsupported selection item for basic indexing; expected integer or slice, got {item_type}"
+                        )))
+                    }
+                }
             }
         }
 
@@ -71,12 +76,12 @@ impl ArrayIndex {
     pub fn get_ranges_and_squeeze_dims(
         &self,
         shape: &Vec<u64>,
-    ) -> PyResult<(Vec<Range<u64>>, Vec<usize>, Vec<usize>)> {
-        // Count how many actual dimensions are consumed by non-NewAxis indices
+    ) -> PyResult<(Vec<Range<u64>>, Vec<usize>)> {
+        // Count how many actual dimensions are consumed by non-ellipsis indices.
         let consumed_dims: usize = self
             .0
             .iter()
-            .filter(|&x| !matches!(x, IndexType::NewAxis | IndexType::Ellipsis))
+            .filter(|&x| !matches!(x, IndexType::Ellipsis))
             .count();
         if consumed_dims > shape.len() {
             return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
@@ -86,7 +91,6 @@ impl ArrayIndex {
 
         let mut ranges = Vec::new();
         let mut squeeze_dims = Vec::new();
-        let mut newaxis_dims = Vec::new();
         let mut current_dim = 0;
 
         let mut shape_idx = 0;
@@ -94,7 +98,7 @@ impl ArrayIndex {
         let explicit_dims: usize = self
             .0
             .iter()
-            .filter(|&x| !matches!(x, IndexType::Ellipsis | IndexType::NewAxis))
+            .filter(|&x| !matches!(x, IndexType::Ellipsis))
             .count();
         let ellipsis_dims = shape.len().saturating_sub(explicit_dims);
 
@@ -183,10 +187,6 @@ impl ArrayIndex {
                     shape_idx += 1;
                     current_dim += 1;
                 }
-                IndexType::NewAxis => {
-                    newaxis_dims.push(current_dim);
-                    current_dim += 1;
-                }
             }
         }
 
@@ -200,21 +200,7 @@ impl ArrayIndex {
         }
         squeeze_dims.sort_by(|a, b| b.cmp(a));
 
-        // Adjust squeeze_dims from output space to read-array space:
-        // each NewAxis before a squeeze dim shifts it left by 1.
-        for pos in squeeze_dims.iter_mut() {
-            let shift = newaxis_dims.iter().filter(|&&n| n < *pos).count();
-            *pos -= shift;
-        }
-
-        // Adjust newaxis_dims from output space to post-squeeze space:
-        // each squeezed dim before a NewAxis shifts it left by 1.
-        for pos in newaxis_dims.iter_mut() {
-            let shift = squeeze_dims.iter().filter(|&&s| s < *pos).count();
-            *pos -= shift;
-        }
-
-        Ok((ranges, squeeze_dims, newaxis_dims))
+        Ok((ranges, squeeze_dims))
     }
 
     fn normalize_index(idx: i64, dim_size: u64) -> PyResult<u64> {
@@ -265,22 +251,12 @@ mod tests {
                 _ => panic!("Expected Int type"),
             }
 
-            // Test None (NewAxis)
-            let none_value = py.None();
-            let single_none_tuple = pyo3::types::PyTuple::new(py, [&none_value]).unwrap();
-            let none_index = ArrayIndex::extract(single_none_tuple.as_any().as_borrowed()).unwrap();
-            match none_index.0[0] {
-                IndexType::NewAxis => (),
-                _ => panic!("Expected NewAxis type"),
-            }
-
             // Test combination of different types
             let mixed_tuple = pyo3::types::PyTuple::new(
                 py,
                 [
                     &slice.into_any(),                            // slice
                     &42i64.into_pyobject(py).unwrap().into_any(), // integer
-                    py.None().bind(py),                           // NewAxis
                 ],
             )
             .unwrap();
@@ -299,11 +275,6 @@ mod tests {
             match mixed_index.0[1] {
                 IndexType::Int(val) => assert_eq!(val, 42),
                 _ => panic!("Expected Int type"),
-            }
-
-            match mixed_index.0[2] {
-                IndexType::NewAxis => (),
-                _ => panic!("Expected NewAxis type"),
             }
 
             // Test slice with None values (open-ended slices)
@@ -393,134 +364,19 @@ mod tests {
     }
 
     #[test]
-    fn test_newaxis() {
+    fn test_unsupported_selection() {
         Python::initialize();
 
         Python::attach(|py| {
-            // arr[np.newaxis] on shape (5,)
-            let shape = vec![5];
             let none = py.None();
             let none_value = none.bind(py);
             let tuple = pyo3::types::PyTuple::new(py, [none_value]).unwrap();
-            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-            assert_eq!(ranges.len(), 1);
-            assert_eq!(ranges[0], Range { start: 0, end: 5 });
-            assert!(squeeze.is_empty());
-            assert_eq!(newaxis, vec![0]);
-
-            // arr[np.newaxis, :3] on shape (5,)
-            let slice = PySlice::new(py, 0, 3, 1);
-            let tuple = pyo3::types::PyTuple::new(
-                py,
-                [none_value, &slice.into_any()],
-            )
-            .unwrap();
-            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-            assert_eq!(ranges.len(), 1);
-            assert_eq!(ranges[0], Range { start: 0, end: 3 });
-            assert!(squeeze.is_empty());
-            assert_eq!(newaxis, vec![0]);
-
-            // arr[1, np.newaxis] on shape (5,)
-            let int_value = 1i64.into_pyobject(py).unwrap();
-            let tuple = pyo3::types::PyTuple::new(
-                py,
-                [&int_value.clone().into_any(), none_value],
-            )
-            .unwrap();
-            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-            assert_eq!(ranges.len(), 1);
-            assert_eq!(ranges[0], Range { start: 1, end: 2 });
-            assert_eq!(squeeze, vec![0]);
-            assert_eq!(newaxis, vec![0]);
-
-            // arr[np.newaxis, 1] on shape (5,) — newaxis then int
-            let tuple = pyo3::types::PyTuple::new(
-                py,
-                [none_value, &int_value.into_any()],
-            )
-            .unwrap();
-            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-            assert_eq!(ranges.len(), 1);
-            assert_eq!(ranges[0], Range { start: 1, end: 2 });
-            assert_eq!(squeeze, vec![0]);
-            assert_eq!(newaxis, vec![0]);
-
-            // arr[np.newaxis, np.newaxis] on shape (5,) — two newaxis
-            let tuple = pyo3::types::PyTuple::new(
-                py,
-                [none_value, none_value],
-            )
-            .unwrap();
-            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-            assert_eq!(ranges.len(), 1);
-            assert_eq!(ranges[0], Range { start: 0, end: 5 });
-            assert!(squeeze.is_empty());
-            assert_eq!(newaxis, vec![0, 1]);
-        });
-    }
-
-    #[test]
-    fn test_ellipsis_with_newaxis() {
-        Python::initialize();
-
-        Python::attach(|py| {
-            let shape = vec![2, 3, 4, 5];
-            let ellipsis = pyo3::types::PyEllipsis::get(py).into_any();
-            let none = py.None();
-            let none_value = none.bind(py);
-
-            // arr[..., np.newaxis] on shape (2,3,4,5)
-            let tuple = pyo3::types::PyTuple::new(
-                py,
-                [&ellipsis, none_value],
-            )
-            .unwrap();
-            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-            assert_eq!(ranges.len(), 4);
-            assert_eq!(ranges[0], Range { start: 0, end: 2 });
-            assert_eq!(ranges[1], Range { start: 0, end: 3 });
-            assert_eq!(ranges[2], Range { start: 0, end: 4 });
-            assert_eq!(ranges[3], Range { start: 0, end: 5 });
-            assert!(squeeze.is_empty());
-            assert_eq!(newaxis, vec![4]);
-
-            // arr[np.newaxis, ...] on shape (2,3,4,5)
-            let tuple = pyo3::types::PyTuple::new(
-                py,
-                [none_value, &ellipsis],
-            )
-            .unwrap();
-            let index = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap();
-            let (ranges, squeeze, newaxis) = index.get_ranges_and_squeeze_dims(&shape).unwrap();
-            assert_eq!(ranges.len(), 4);
-            assert_eq!(ranges[0], Range { start: 0, end: 2 });
-            assert_eq!(ranges[1], Range { start: 0, end: 3 });
-            assert_eq!(ranges[2], Range { start: 0, end: 4 });
-            assert_eq!(ranges[3], Range { start: 0, end: 5 });
-            assert!(squeeze.is_empty());
-            assert_eq!(newaxis, vec![0]);
-        });
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_input() {
-        Python::initialize();
-
-        Python::attach(|py| {
-            let invalid_value = "not_an_index"
-                .into_pyobject(py)
-                .expect("Failed to create object");
-            let invalid_tuple =
-                pyo3::types::PyTuple::new(py, [&invalid_value]).expect("Failed to create tuple");
-            let _should_fail = ArrayIndex::extract(invalid_tuple.as_any().as_borrowed()).unwrap();
+            let error = ArrayIndex::extract(tuple.as_any().as_borrowed()).unwrap_err();
+            assert!(error.is_instance_of::<pyo3::exceptions::PyIndexError>(py));
+            assert_eq!(
+                error.to_string(),
+                "IndexError: unsupported selection item for basic indexing; expected integer or slice, got <class 'NoneType'>"
+            );
         });
     }
 

--- a/src/array_index.rs
+++ b/src/array_index.rs
@@ -77,13 +77,13 @@ impl ArrayIndex {
         &self,
         shape: &[u64],
     ) -> PyResult<(Vec<Range<u64>>, Vec<usize>)> {
-        // Count how many actual dimensions are consumed by non-ellipsis indices.
-        let consumed_dims: usize = self
+        // Each explicit index (integer or slice) applies to one input dimension.
+        let explicit_dims: usize = self
             .0
             .iter()
             .filter(|&x| !matches!(x, IndexType::Ellipsis))
             .count();
-        if consumed_dims > shape.len() {
+        if explicit_dims > shape.len() {
             return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
                 "Too many indices for array",
             ));
@@ -94,11 +94,6 @@ impl ArrayIndex {
 
         let mut shape_idx = 0;
         let mut ellipsis_seen = false;
-        let explicit_dims: usize = self
-            .0
-            .iter()
-            .filter(|&x| !matches!(x, IndexType::Ellipsis))
-            .count();
         let ellipsis_dims = shape.len().saturating_sub(explicit_dims);
 
         for idx in &self.0 {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -477,22 +477,24 @@ impl OmFileReader {
         })
     }
 
-    /// Read data from the open variable.om file using numpy-style indexing.
+    /// Read data from the open variable.om file using basic file-backed array indexing.
     ///
     /// Currently only slices with step 1 are supported.
     ///
-    /// Follows NumPy indexing semantics:
+    /// Supports integer, slice, and ellipsis selectors:
     /// - Integer indices remove that dimension
     /// - Slice indices (even of length 1) preserve the dimension
+    /// - Ellipsis expands to the remaining dimensions
     ///
     /// Args:
     ///     ranges (:py:data:`omfiles.types.BasicSelection`): Index expression to select data from the array.
-    ///         Supports basic numpy indexing.
+    ///         Supports integers, slices, and ellipsis. ``None``/``numpy.newaxis`` is not supported.
     ///
     /// Returns:
     ///     numpy.typing.NDArray[numpy.int8 | numpy.int16 | numpy.int32 | numpy.int64 | numpy.uint8 | numpy.uint16 | numpy.uint32 | numpy.uint64 | numpy.float32 | numpy.float64]: NDArray containing the requested data with squeezed singleton dimensions.
     ///
     /// Raises:
+    ///     IndexError: If a selector is unsupported or there are too many indices.
     ///     ValueError: If the requested ranges are invalid or if there's an error reading the data.
     fn read_array<'py>(&self, py: Python<'_>, ranges: ArrayIndex) -> PyResult<OmFileTypedArray> {
         py.detach(|| {
@@ -500,7 +502,7 @@ impl OmFileReader {
                 let array_reader = reader
                     .expect_array_with_io_sizes(65536, 512)
                     .map_err(|_| Self::only_arrays_error())?;
-                let (read_ranges, squeeze_dims, newaxis_dims) =
+                let (read_ranges, squeeze_dims) =
                     ranges.get_ranges_and_squeeze_dims(&self.shape)?;
                 let dtype = array_reader.data_type();
 
@@ -522,7 +524,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Int8(array))
                     }
@@ -531,7 +532,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Uint8(array))
                     }
@@ -540,7 +540,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Int16(array))
                     }
@@ -549,7 +548,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Uint16(array))
                     }
@@ -558,7 +556,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Int32(array))
                     }
@@ -567,7 +564,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Uint32(array))
                     }
@@ -576,7 +572,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Int64(array))
                     }
@@ -585,7 +580,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Uint64(array))
                     }
@@ -594,7 +588,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Float(array))
                     }
@@ -603,7 +596,6 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
-                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Double(array))
                     }
@@ -656,14 +648,13 @@ fn read_and_process_array<T: Element + OmFileArrayDataType + Clone + Zero>(
     reader: &OmFileArrayRs<impl OmFileReaderBackend>,
     read_ranges: &[Range<u64>],
     squeeze_dims: &[usize],
-    newaxis_dims: &[usize],
 ) -> PyResult<ndarray::ArrayD<T>> {
     let array = reader
         .read::<T>(read_ranges)
         .map_err(convert_omfilesrs_error)?;
 
     // Filter out dimensions of size 1 that correspond to integer indices
-    let mut new_shape: Vec<usize> = array
+    let new_shape: Vec<usize> = array
         .shape()
         .iter()
         .enumerate()
@@ -675,13 +666,6 @@ fn read_and_process_array<T: Element + OmFileArrayDataType + Clone + Zero>(
             }
         })
         .collect();
-
-    // Insert size-1 dimensions for NewAxis, sorted ascending
-    let mut newaxis_sorted = newaxis_dims.to_vec();
-    newaxis_sorted.sort();
-    for &pos in newaxis_sorted.iter() {
-        new_shape.insert(pos, 1);
-    }
 
     Ok(array
         .into_shape_with_order(new_shape)

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -479,6 +479,7 @@ impl OmFileReader {
 
     /// Read data from the open variable.om file using basic file-backed array indexing.
     ///
+    /// Slice bounds are clipped to the array dimensions and empty selections return empty arrays.
     /// Currently only slices with step 1 are supported.
     ///
     /// Supports integer, slice, and ellipsis selectors:
@@ -502,8 +503,8 @@ impl OmFileReader {
                 let array_reader = reader
                     .expect_array_with_io_sizes(65536, 512)
                     .map_err(|_| Self::only_arrays_error())?;
-                let (read_ranges, squeeze_dims) =
-                    ranges.get_ranges_and_squeeze_dims(&self.shape)?;
+                let (read_ranges, output_shape) =
+                    ranges.get_ranges_and_output_shape(&self.shape)?;
                 let dtype = array_reader.data_type();
 
                 let untyped_py_array_or_error = match dtype {
@@ -523,7 +524,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<i8>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Int8(array))
                     }
@@ -531,7 +532,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<u8>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Uint8(array))
                     }
@@ -539,7 +540,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<i16>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Int16(array))
                     }
@@ -547,7 +548,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<u16>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Uint16(array))
                     }
@@ -555,7 +556,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<i32>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Int32(array))
                     }
@@ -563,7 +564,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<u32>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Uint32(array))
                     }
@@ -571,7 +572,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<i64>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Int64(array))
                     }
@@ -579,7 +580,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<u64>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Uint64(array))
                     }
@@ -587,7 +588,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<f32>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Float(array))
                     }
@@ -595,7 +596,7 @@ impl OmFileReader {
                         let array = read_and_process_array::<f64>(
                             &array_reader,
                             &read_ranges,
-                            &squeeze_dims,
+                            &output_shape,
                         )?;
                         Ok(OmFileTypedArray::Double(array))
                     }
@@ -647,28 +648,18 @@ impl OmFileReader {
 fn read_and_process_array<T: Element + OmFileArrayDataType + Clone + Zero>(
     reader: &OmFileArrayRs<impl OmFileReaderBackend>,
     read_ranges: &[Range<u64>],
-    squeeze_dims: &[usize],
+    output_shape: &[usize],
 ) -> PyResult<ndarray::ArrayD<T>> {
+    if read_ranges.iter().any(Range::is_empty) {
+        return Ok(ndarray::ArrayD::<T>::zeros(output_shape));
+    }
+
     let array = reader
         .read::<T>(read_ranges)
         .map_err(convert_omfilesrs_error)?;
 
-    // Filter out dimensions of size 1 that correspond to integer indices
-    let new_shape: Vec<usize> = array
-        .shape()
-        .iter()
-        .enumerate()
-        .filter_map(|(i, &dim)| {
-            if squeeze_dims.contains(&i) {
-                None
-            } else {
-                Some(dim)
-            }
-        })
-        .collect();
-
     Ok(array
-        .into_shape_with_order(new_shape)
+        .into_shape_with_order(output_shape)
         .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -208,8 +208,8 @@ impl OmFileReader {
 
             if !bound_object.hasattr("cat_file")? || !bound_object.hasattr("size")? {
                 return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        "Input must be a valid fsspec file object with read, seek methods and fs attribute",
-                    ));
+                    "Input must be a valid fsspec file object with `cat_file` and `size` methods.",
+                ));
             }
 
             let backend = ReaderBackendImpl::FsSpec(FsSpecBackend::new(fs_obj, path)?);
@@ -500,7 +500,7 @@ impl OmFileReader {
                 let array_reader = reader
                     .expect_array_with_io_sizes(65536, 512)
                     .map_err(|_| Self::only_arrays_error())?;
-                let (read_ranges, squeeze_dims) =
+                let (read_ranges, squeeze_dims, newaxis_dims) =
                     ranges.get_ranges_and_squeeze_dims(&self.shape)?;
                 let dtype = array_reader.data_type();
 
@@ -522,6 +522,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Int8(array))
                     }
@@ -530,6 +531,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Uint8(array))
                     }
@@ -538,6 +540,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Int16(array))
                     }
@@ -546,6 +549,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Uint16(array))
                     }
@@ -554,6 +558,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Int32(array))
                     }
@@ -562,6 +567,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Uint32(array))
                     }
@@ -570,6 +576,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Int64(array))
                     }
@@ -578,6 +585,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Uint64(array))
                     }
@@ -586,6 +594,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Float(array))
                     }
@@ -594,6 +603,7 @@ impl OmFileReader {
                             &array_reader,
                             &read_ranges,
                             &squeeze_dims,
+                            &newaxis_dims,
                         )?;
                         Ok(OmFileTypedArray::Double(array))
                     }
@@ -646,15 +656,14 @@ fn read_and_process_array<T: Element + OmFileArrayDataType + Clone + Zero>(
     reader: &OmFileArrayRs<impl OmFileReaderBackend>,
     read_ranges: &[Range<u64>],
     squeeze_dims: &[usize],
+    newaxis_dims: &[usize],
 ) -> PyResult<ndarray::ArrayD<T>> {
     let array = reader
         .read::<T>(read_ranges)
         .map_err(convert_omfilesrs_error)?;
 
     // Filter out dimensions of size 1 that correspond to integer indices
-    // This assumes the `array` returned by `read` has the full dimensionality
-    // matching `read_ranges` (which it does in omfiles-rs).
-    let new_shape: Vec<usize> = array
+    let mut new_shape: Vec<usize> = array
         .shape()
         .iter()
         .enumerate()
@@ -666,6 +675,13 @@ fn read_and_process_array<T: Element + OmFileArrayDataType + Clone + Zero>(
             }
         })
         .collect();
+
+    // Insert size-1 dimensions for NewAxis, sorted ascending
+    let mut newaxis_sorted = newaxis_dims.to_vec();
+    newaxis_sorted.sort();
+    for &pos in newaxis_sorted.iter() {
+        new_shape.insert(pos, 1);
+    }
 
     Ok(array
         .into_shape_with_order(new_shape)

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -459,7 +459,7 @@ impl OmFileReaderAsync {
     ///     TypeError: If the data type is not supported.
     async fn read_array<'py>(&self, ranges: ArrayIndex) -> PyResult<OmFileTypedArray> {
         // Convert the Python ranges to Rust ranges
-        let (read_ranges, squeeze_dims) = ranges.get_ranges_and_squeeze_dims(&self.shape)?;
+        let (read_ranges, squeeze_dims, newaxis_dims) = ranges.get_ranges_and_squeeze_dims(&self.shape)?;
 
         let guard = self
             .reader
@@ -479,52 +479,52 @@ impl OmFileReaderAsync {
         let result = match data_type {
             OmDataType::Int8Array => {
                 let array =
-                    read_and_process_array::<i8>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<i8>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Int8(array))
             }
             OmDataType::Int16Array => {
                 let array =
-                    read_and_process_array::<i16>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<i16>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Int16(array))
             }
             OmDataType::Int32Array => {
                 let array =
-                    read_and_process_array::<i32>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<i32>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Int32(array))
             }
             OmDataType::Int64Array => {
                 let array =
-                    read_and_process_array::<i64>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<i64>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Int64(array))
             }
             OmDataType::Uint8Array => {
                 let array =
-                    read_and_process_array::<u8>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<u8>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Uint8(array))
             }
             OmDataType::Uint16Array => {
                 let array =
-                    read_and_process_array::<u16>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<u16>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Uint16(array))
             }
             OmDataType::Uint32Array => {
                 let array =
-                    read_and_process_array::<u32>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<u32>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Uint32(array))
             }
             OmDataType::Uint64Array => {
                 let array =
-                    read_and_process_array::<u64>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<u64>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Uint64(array))
             }
             OmDataType::FloatArray => {
                 let array =
-                    read_and_process_array::<f32>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<f32>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Float(array))
             }
             OmDataType::DoubleArray => {
                 let array =
-                    read_and_process_array::<f64>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<f64>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
                 Ok(OmFileTypedArray::Double(array))
             }
             _ => {
@@ -568,6 +568,7 @@ async fn read_and_process_array<T>(
     reader: &OmFileReaderAsyncRs<AsyncReaderBackendImpl>,
     read_ranges: &[Range<u64>],
     squeeze_dims: &[usize],
+    newaxis_dims: &[usize],
 ) -> PyResult<ndarray::ArrayD<T>>
 where
     T: Element + OmFileArrayDataType + Clone + Zero + Send + Sync + 'static,
@@ -580,10 +581,7 @@ where
         .await
         .map_err(convert_omfilesrs_error)?;
 
-    // Filter out dimensions of size 1 that correspond to integer indices
-    // This assumes the `array` returned by `read` has the full dimensionality
-    // matching `read_ranges` (which it does in omfiles-rs).
-    let new_shape: Vec<usize> = array
+    let mut new_shape: Vec<usize> = array
         .shape()
         .iter()
         .enumerate()
@@ -595,6 +593,12 @@ where
             }
         })
         .collect();
+
+    let mut newaxis_sorted = newaxis_dims.to_vec();
+    newaxis_sorted.sort();
+    for &pos in newaxis_sorted.iter() {
+        new_shape.insert(pos, 1);
+    }
 
     Ok(array
         .into_shape_with_order(new_shape)

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -449,17 +449,19 @@ impl OmFileReaderAsync {
     /// Read data from the array concurrently based on specified ranges.
     ///
     /// Args:
-    ///     ranges (:py:data:`omfiles.types.BasicSelection`): Index or slice object specifying the ranges to read.
+    ///     ranges (:py:data:`omfiles.types.BasicSelection`): Integer, slice, or ellipsis expression specifying the
+    ///         ranges to read. ``None``/``numpy.newaxis`` is not supported.
     ///
     /// Returns:
     ///     OmFileTypedArray: Array data of the appropriate numpy type.
     ///
     /// Raises:
+    ///     IndexError: If a selector is unsupported or there are too many indices.
     ///     ValueError: If the reader is closed.
     ///     TypeError: If the data type is not supported.
     async fn read_array<'py>(&self, ranges: ArrayIndex) -> PyResult<OmFileTypedArray> {
         // Convert the Python ranges to Rust ranges
-        let (read_ranges, squeeze_dims, newaxis_dims) = ranges.get_ranges_and_squeeze_dims(&self.shape)?;
+        let (read_ranges, squeeze_dims) = ranges.get_ranges_and_squeeze_dims(&self.shape)?;
 
         let guard = self
             .reader
@@ -479,52 +481,52 @@ impl OmFileReaderAsync {
         let result = match data_type {
             OmDataType::Int8Array => {
                 let array =
-                    read_and_process_array::<i8>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<i8>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Int8(array))
             }
             OmDataType::Int16Array => {
                 let array =
-                    read_and_process_array::<i16>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<i16>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Int16(array))
             }
             OmDataType::Int32Array => {
                 let array =
-                    read_and_process_array::<i32>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<i32>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Int32(array))
             }
             OmDataType::Int64Array => {
                 let array =
-                    read_and_process_array::<i64>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<i64>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Int64(array))
             }
             OmDataType::Uint8Array => {
                 let array =
-                    read_and_process_array::<u8>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<u8>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Uint8(array))
             }
             OmDataType::Uint16Array => {
                 let array =
-                    read_and_process_array::<u16>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<u16>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Uint16(array))
             }
             OmDataType::Uint32Array => {
                 let array =
-                    read_and_process_array::<u32>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<u32>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Uint32(array))
             }
             OmDataType::Uint64Array => {
                 let array =
-                    read_and_process_array::<u64>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<u64>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Uint64(array))
             }
             OmDataType::FloatArray => {
                 let array =
-                    read_and_process_array::<f32>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<f32>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Float(array))
             }
             OmDataType::DoubleArray => {
                 let array =
-                    read_and_process_array::<f64>(reader, &read_ranges, &squeeze_dims, &newaxis_dims).await?;
+                    read_and_process_array::<f64>(reader, &read_ranges, &squeeze_dims).await?;
                 Ok(OmFileTypedArray::Double(array))
             }
             _ => {
@@ -568,7 +570,6 @@ async fn read_and_process_array<T>(
     reader: &OmFileReaderAsyncRs<AsyncReaderBackendImpl>,
     read_ranges: &[Range<u64>],
     squeeze_dims: &[usize],
-    newaxis_dims: &[usize],
 ) -> PyResult<ndarray::ArrayD<T>>
 where
     T: Element + OmFileArrayDataType + Clone + Zero + Send + Sync + 'static,
@@ -581,7 +582,7 @@ where
         .await
         .map_err(convert_omfilesrs_error)?;
 
-    let mut new_shape: Vec<usize> = array
+    let new_shape: Vec<usize> = array
         .shape()
         .iter()
         .enumerate()
@@ -593,12 +594,6 @@ where
             }
         })
         .collect();
-
-    let mut newaxis_sorted = newaxis_dims.to_vec();
-    newaxis_sorted.sort();
-    for &pos in newaxis_sorted.iter() {
-        new_shape.insert(pos, 1);
-    }
 
     Ok(array
         .into_shape_with_order(new_shape)

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -448,6 +448,9 @@ impl OmFileReaderAsync {
 
     /// Read data from the array concurrently based on specified ranges.
     ///
+    /// Slice bounds are clipped to the array dimensions and empty selections return empty arrays.
+    /// Currently only slices with step 1 are supported.
+    ///
     /// Args:
     ///     ranges (:py:data:`omfiles.types.BasicSelection`): Integer, slice, or ellipsis expression specifying the
     ///         ranges to read. ``None``/``numpy.newaxis`` is not supported.
@@ -461,7 +464,7 @@ impl OmFileReaderAsync {
     ///     TypeError: If the data type is not supported.
     async fn read_array<'py>(&self, ranges: ArrayIndex) -> PyResult<OmFileTypedArray> {
         // Convert the Python ranges to Rust ranges
-        let (read_ranges, squeeze_dims) = ranges.get_ranges_and_squeeze_dims(&self.shape)?;
+        let (read_ranges, output_shape) = ranges.get_ranges_and_output_shape(&self.shape)?;
 
         let guard = self
             .reader
@@ -481,52 +484,52 @@ impl OmFileReaderAsync {
         let result = match data_type {
             OmDataType::Int8Array => {
                 let array =
-                    read_and_process_array::<i8>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<i8>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Int8(array))
             }
             OmDataType::Int16Array => {
                 let array =
-                    read_and_process_array::<i16>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<i16>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Int16(array))
             }
             OmDataType::Int32Array => {
                 let array =
-                    read_and_process_array::<i32>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<i32>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Int32(array))
             }
             OmDataType::Int64Array => {
                 let array =
-                    read_and_process_array::<i64>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<i64>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Int64(array))
             }
             OmDataType::Uint8Array => {
                 let array =
-                    read_and_process_array::<u8>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<u8>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Uint8(array))
             }
             OmDataType::Uint16Array => {
                 let array =
-                    read_and_process_array::<u16>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<u16>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Uint16(array))
             }
             OmDataType::Uint32Array => {
                 let array =
-                    read_and_process_array::<u32>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<u32>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Uint32(array))
             }
             OmDataType::Uint64Array => {
                 let array =
-                    read_and_process_array::<u64>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<u64>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Uint64(array))
             }
             OmDataType::FloatArray => {
                 let array =
-                    read_and_process_array::<f32>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<f32>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Float(array))
             }
             OmDataType::DoubleArray => {
                 let array =
-                    read_and_process_array::<f64>(reader, &read_ranges, &squeeze_dims).await?;
+                    read_and_process_array::<f64>(reader, &read_ranges, &output_shape).await?;
                 Ok(OmFileTypedArray::Double(array))
             }
             _ => {
@@ -569,7 +572,7 @@ impl OmFileReaderAsync {
 async fn read_and_process_array<T>(
     reader: &OmFileReaderAsyncRs<AsyncReaderBackendImpl>,
     read_ranges: &[Range<u64>],
-    squeeze_dims: &[usize],
+    output_shape: &[usize],
 ) -> PyResult<ndarray::ArrayD<T>>
 where
     T: Element + OmFileArrayDataType + Clone + Zero + Send + Sync + 'static,
@@ -577,26 +580,17 @@ where
     let reader = reader
         .expect_array_with_io_sizes(65536, 512)
         .map_err(convert_omfilesrs_error)?;
+    if read_ranges.iter().any(Range::is_empty) {
+        return Ok(ndarray::ArrayD::<T>::zeros(output_shape));
+    }
+
     let array = reader
         .read::<T>(read_ranges)
         .await
         .map_err(convert_omfilesrs_error)?;
 
-    let new_shape: Vec<usize> = array
-        .shape()
-        .iter()
-        .enumerate()
-        .filter_map(|(i, &dim)| {
-            if squeeze_dims.contains(&i) {
-                None
-            } else {
-                Some(dim)
-            }
-        })
-        .collect();
-
     Ok(array
-        .into_shape_with_order(new_shape)
+        .into_shape_with_order(output_shape)
         .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -403,6 +403,16 @@ async def test_read_async(temp_om_file):
         with pytest.raises(IndexError, match=unsupported_selection):
             await reader.read_array((slice(None), None))
 
+        clipped = await reader.read_array((slice(-99, 99), slice(None)))
+        np.testing.assert_array_equal(clipped, data)
+
+        empty = await reader.read_array((slice(3, 1), slice(None)))
+        assert empty.shape == (0, 5)
+        assert empty.dtype == np.float32
+
+        with pytest.raises(IndexError):
+            await reader.read_array((5, 0))
+
     # Test that not awaiting results before closing the reader is safe
     with await omfiles.OmFileReaderAsync.from_path(temp_om_file) as reader_we_dont_await:
         for _ in range(100):
@@ -479,6 +489,7 @@ def test_indexing_integer(temp_om_file):
     ref = _ref_data()
     reader = omfiles.OmFileReader(temp_om_file)
     np.testing.assert_array_equal(reader[0], ref[0])
+    np.testing.assert_array_equal(reader[-5], ref[-5])
     np.testing.assert_array_equal(reader[-1], ref[-1])
     np.testing.assert_array_equal(reader[2, 3], np.float32(ref[2, 3]))
     reader.close()
@@ -514,6 +525,32 @@ def test_indexing_negative_slice(temp_om_file):
     reader.close()
 
 
+@pytest.mark.parametrize(
+    "selection",
+    [
+        (slice(-99, None), slice(None)),
+        (slice(None, 99), slice(None)),
+        (slice(99, None), slice(None)),
+        (slice(None, -99), slice(None)),
+        (slice(0, 0), slice(None)),
+        (slice(3, 1), slice(None)),
+        (slice(None), slice(99, None)),
+        (slice(0, 0), 2),
+    ],
+)
+def test_indexing_clipped_and_empty_slices(temp_om_file, selection):
+    ref = _ref_data()
+    reader = omfiles.OmFileReader(temp_om_file)
+
+    actual = reader[selection]
+    expected = ref[selection]
+
+    np.testing.assert_array_equal(actual, expected)
+    assert actual.shape == expected.shape
+    assert actual.dtype == expected.dtype
+    reader.close()
+
+
 def test_indexing_rejects_unsupported_selection(temp_om_file):
     reader = omfiles.OmFileReader(temp_om_file)
     unsupported_selection = (
@@ -543,6 +580,10 @@ def test_indexing_mixed(temp_om_file):
 
 def test_indexing_errors(temp_om_file):
     reader = omfiles.OmFileReader(temp_om_file)
+    with pytest.raises(IndexError):
+        _ = reader[5]
+    with pytest.raises(IndexError):
+        _ = reader[-6]
     with pytest.raises(IndexError):
         _ = reader[10]
     with pytest.raises(IndexError):

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -463,6 +463,85 @@ def test_reader_close(temp_om_file):
     )
 
 
+def _ref_data():
+    return np.arange(25, dtype=np.float32).reshape(5, 5)
+
+
+def test_indexing_integer(temp_om_file):
+    ref = _ref_data()
+    reader = omfiles.OmFileReader(temp_om_file)
+    np.testing.assert_array_equal(reader[0], ref[0])
+    np.testing.assert_array_equal(reader[-1], ref[-1])
+    np.testing.assert_array_equal(reader[2, 3], np.float32(ref[2, 3]))
+    reader.close()
+
+
+def test_indexing_slice(temp_om_file):
+    ref = _ref_data()
+    reader = omfiles.OmFileReader(temp_om_file)
+    np.testing.assert_array_equal(reader[1:4], ref[1:4])
+    np.testing.assert_array_equal(reader[1:4, 2:5], ref[1:4, 2:5])
+    np.testing.assert_array_equal(reader[:3, :2], ref[:3, :2])
+    np.testing.assert_array_equal(reader[2:, 3:], ref[2:, 3:])
+    reader.close()
+
+
+def test_indexing_ellipsis(temp_om_file):
+    ref = _ref_data()
+    reader = omfiles.OmFileReader(temp_om_file)
+    np.testing.assert_array_equal(reader[...], ref[...])
+    np.testing.assert_array_equal(reader[1, ...], ref[1, ...])
+    np.testing.assert_array_equal(reader[..., 2], ref[..., 2])
+    np.testing.assert_array_equal(reader[1:4, ...], ref[1:4, ...])
+    np.testing.assert_array_equal(reader[..., 2:5], ref[..., 2:5])
+    reader.close()
+
+
+def test_indexing_negative_slice(temp_om_file):
+    ref = _ref_data()
+    reader = omfiles.OmFileReader(temp_om_file)
+    np.testing.assert_array_equal(reader[-3:], ref[-3:])
+    np.testing.assert_array_equal(reader[-3:-1], ref[-3:-1])
+    np.testing.assert_array_equal(reader[-4:-1, -3:], ref[-4:-1, -3:])
+    reader.close()
+
+
+def test_indexing_newaxis(temp_om_file):
+    ref = _ref_data()
+    reader = omfiles.OmFileReader(temp_om_file)
+    np.testing.assert_array_equal(reader[None], ref[None])
+    np.testing.assert_array_equal(reader[None, :3], ref[None, :3])
+    np.testing.assert_array_equal(reader[1, None], ref[1, None])
+    np.testing.assert_array_equal(reader[None, 1], ref[None, 1])
+    np.testing.assert_array_equal(reader[None, None], ref[None, None])
+    np.testing.assert_array_equal(reader[..., None], ref[..., None])
+    np.testing.assert_array_equal(reader[None, ...], ref[None, ...])
+    reader.close()
+
+
+def test_indexing_mixed(temp_om_file):
+    ref = _ref_data()
+    reader = omfiles.OmFileReader(temp_om_file)
+    np.testing.assert_array_equal(reader[1:4, 2], ref[1:4, 2])
+    np.testing.assert_array_equal(reader[0, 1:4], ref[0, 1:4])
+    np.testing.assert_array_equal(reader[1:4, ...], ref[1:4, ...])
+    np.testing.assert_array_equal(reader[..., 2:5], ref[..., 2:5])
+    reader.close()
+
+
+def test_indexing_errors(temp_om_file):
+    reader = omfiles.OmFileReader(temp_om_file)
+    with pytest.raises(IndexError):
+        _ = reader[10]
+    with pytest.raises(IndexError):
+        _ = reader[0, 10]
+    with pytest.raises(IndexError):
+        _ = reader[-10]
+    with pytest.raises(IndexError):
+        _ = reader[0, 0, 0]
+    reader.close()
+
+
 def test_child_traversal(temp_hierarchical_om_file):
     reader = omfiles.OmFileReader(temp_hierarchical_om_file)
 

--- a/tests/test_read_write.py
+++ b/tests/test_read_write.py
@@ -395,6 +395,14 @@ async def test_read_async(temp_om_file):
             ],
         )
 
+        unsupported_selection = (
+            "unsupported selection item for basic indexing; expected integer or slice, got <class 'NoneType'>"
+        )
+        with pytest.raises(IndexError, match=unsupported_selection):
+            await reader.read_array(None)
+        with pytest.raises(IndexError, match=unsupported_selection):
+            await reader.read_array((slice(None), None))
+
     # Test that not awaiting results before closing the reader is safe
     with await omfiles.OmFileReaderAsync.from_path(temp_om_file) as reader_we_dont_await:
         for _ in range(100):
@@ -506,16 +514,20 @@ def test_indexing_negative_slice(temp_om_file):
     reader.close()
 
 
-def test_indexing_newaxis(temp_om_file):
-    ref = _ref_data()
+def test_indexing_rejects_unsupported_selection(temp_om_file):
     reader = omfiles.OmFileReader(temp_om_file)
-    np.testing.assert_array_equal(reader[None], ref[None])
-    np.testing.assert_array_equal(reader[None, :3], ref[None, :3])
-    np.testing.assert_array_equal(reader[1, None], ref[1, None])
-    np.testing.assert_array_equal(reader[None, 1], ref[None, 1])
-    np.testing.assert_array_equal(reader[None, None], ref[None, None])
-    np.testing.assert_array_equal(reader[..., None], ref[..., None])
-    np.testing.assert_array_equal(reader[None, ...], ref[None, ...])
+    unsupported_selection = (
+        "unsupported selection item for basic indexing; expected integer or slice, got <class 'NoneType'>"
+    )
+
+    with pytest.raises(IndexError, match=unsupported_selection):
+        _ = reader[None]
+    with pytest.raises(IndexError, match=unsupported_selection):
+        _ = reader[:, None]
+    with pytest.raises(IndexError, match=unsupported_selection):
+        _ = reader[..., None]
+    with pytest.raises(IndexError, match=unsupported_selection):
+        _ = reader[None, :, None, 0]
     reader.close()
 
 

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -47,6 +47,13 @@ def test_xarray_backend(temp_om_file):
         ],
     )
 
+    clipped = variable.isel(dim0=slice(-99, 99)).values
+    np.testing.assert_array_equal(clipped, data)
+
+    empty = variable.isel(dim0=slice(3, 1)).values
+    assert empty.shape == (0, 5)
+    assert empty.dtype == np.float32
+
 
 @filter_numpy_size_warning
 def test_xarray_hierarchical_file(empty_temp_om_file):


### PR DESCRIPTION
Fixes indexing to correctly handle clipped and empty slices across synchronous and asynchronous readers while preserving integer, slice, and ellipsis behavior. `newaxis`/`None` indexing was not correct and is removed entirely.